### PR TITLE
bug fix for facebook response

### DIFF
--- a/lib/oauth2client/client.py
+++ b/lib/oauth2client/client.py
@@ -84,7 +84,7 @@ def response_decoder(body):
       params[k] = v
     else:
       params[k] = v[0]
-    return params
+  return params
 
 
 class Credentials(object):


### PR DESCRIPTION
I started using engineauth from last week. This helps me very well.
However I found some bugs. Please let me fix them.

I'm using facebook-login but sometimes it works well but sometime doesn't.
I found problem in libs/oauth2client/client.py

I think someone add patch for this library like below.
https://code.google.com/p/google-api-python-client/issues/detail?id=36

In response_decoder(), body will be "access_token=xxx&expire=xxx".
I expect this method returns dict object like "{access_toke: xxx, expire:xxx}", but it returns only one property, access_token or expire. I think wrong indent is causing this.

Thanks
