### PR TITLE
Optional, configurable feature - redirect callback back to the previous ...

### DIFF
--- a/engineauth/config.py
+++ b/engineauth/config.py
@@ -8,6 +8,7 @@ default_config = {
     'base_uri': '/auth',
     'login_uri': '/login',
     'success_uri': '/',
+    'redirect_back': False,
     'secret_key': 'CHANGE_TO_A_SECRET_KEY', # We add this here for testing only
     'user_model': 'engineauth.models.User',
     'provider.appengine_openid': {

--- a/engineauth/middleware.py
+++ b/engineauth/middleware.py
@@ -93,6 +93,12 @@ class EngineAuthRequest(Request):
             pass
     get_messages = _get_messages
 
+    def _set_redirect_back(self):
+         next_uri = self.referer
+         if next_uri is not None and self._config['redirect_back']:
+            self.session.data['_redirect_uri'] = next_uri
+    set_redirect_uri = _set_redirect_back
+
     def _get_redirect_uri(self):
         try:
             return self.session.data.pop('_redirect_uri').encode('utf-8')
@@ -122,6 +128,8 @@ class AuthMiddleware(object):
         req._config = self._config
         req._load_session()
         req._load_user()
+        if req._config['redirect_back']:
+            req._set_redirect_back()
         resp = None
         # If the requesting url is for engineauth load the strategy
         if environ['PATH_INFO'].startswith(self._config['base_uri']):


### PR DESCRIPTION
Add a config flag that replaces the callback uri (success_uri) with the referer page. Thus the user returns back to the same page.

Related to #9
