### PR TITLE
Fix Twitter log in error if the user has to sign in

### DIFF
--- a/engineauth/middleware.py
+++ b/engineauth/middleware.py
@@ -96,7 +96,7 @@ class EngineAuthRequest(Request):
 
     def _set_redirect_back(self):
          next_uri = self.referer
-         if next_uri is not None and self._config['redirect_back']:
+         if next_uri is not None and self._config['redirect_back'] and self.server_name in next_uri:
             self.session.data['_redirect_uri'] = next_uri
     set_redirect_uri = _set_redirect_back
 
@@ -132,11 +132,11 @@ class AuthMiddleware(object):
         req._config = self._config
         req._load_session()
         req._load_user()
-        if req._config['redirect_back']:
-            req._set_redirect_back()
         resp = None
         # If the requesting url is for engineauth load the strategy
         if environ['PATH_INFO'].startswith(self._base_uri):
+            if req._config['redirect_back']:
+                req._set_redirect_back()
             # extract provider and additional params from the url
             provider, provider_params = self._url_parse_re.match(
                 req.path_info).group(1, 2)

--- a/engineauth/middleware.py
+++ b/engineauth/middleware.py
@@ -95,8 +95,11 @@ class EngineAuthRequest(Request):
     get_messages = _get_messages
 
     def _set_redirect_back(self):
-         next_uri = self.referer
-         if next_uri is not None and self._config['redirect_back'] and self.server_name in next_uri:
+        """ Save a valid url to redirect back after OAuth dance. """
+        next_uri = self.referer
+        # uri is valid if its domain matches the current server name
+        uri_is_valid = re.match(r'(https?://)?' + self.server_name + '.*', next_uri) if next_uri else False
+        if next_uri is not None and self._config['redirect_back'] and uri_is_valid:
             self.session.data['_redirect_uri'] = next_uri
     set_redirect_uri = _set_redirect_back
 


### PR DESCRIPTION
Twitter log in was failing if the user had to sign in in Twitter.

Fix: Only save the redirect_back url on engineauth requests. Check that the url belongs to the current domain, since some requests might contain the social network url as referral
